### PR TITLE
Add triple search and atom pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ This node allows you to interact with the Intuition GraphQL API using different 
 | `fetchTriplesForPredicate` | Fetch triples with a given predicate ID                                           |
 | `fetchTriplesForObject`    | Fetch triples linked to a specific object                                         |
 | `fetchTripleById`          | Fetch a single triple using its unique ID                                         |
-| `fetchAtoms`               | Retrieve a full list of atoms and their metadata (label, value, vault info, etc.) |
+| `fetchAtoms`               | Retrieve a full list of atoms and their metadata (label, value, vault info, etc.) with optional limit/offset |
 | `fetchAtomDetails`         | Fetch detailed data about a specific atom                                         |
+| `searchTriples`            | Search triples server-side using Hasura-style filters                      |
 
 ---
 

--- a/nodes/IntuitionFetch/IntuitionFetch.node.ts
+++ b/nodes/IntuitionFetch/IntuitionFetch.node.ts
@@ -46,11 +46,12 @@ export class IntuitionFetch implements INodeType {
 					{ name: 'Fetch Triples For Object', value: 'fetchTriplesForObject' },
 					{ name: 'Fetch Triple By ID', value: 'fetchTripleById' },
 					{ name: 'Fetch Atoms', value: 'fetchAtoms' },
-					{ name: 'Fetch Atom Details', value: 'fetchAtomDetails' },
-				],
-				default: 'fetchTriples',
-				description: 'Select the operation to perform',
-			},
+                                        { name: 'Fetch Atom Details', value: 'fetchAtomDetails' },
+                                        { name: 'Search Triples', value: 'searchTriples' },
+                                ],
+                                default: 'fetchTriples',
+                                description: 'Select the operation to perform',
+                        },
 			{
 				displayName: 'Subject ID',
 				name: 'subjectId',
@@ -95,22 +96,44 @@ export class IntuitionFetch implements INodeType {
 					},
 				},
 			},
-			{
-				displayName: 'Atom ID',
-				name: 'atomId',
-				type: 'string',
-				default: '',
-				displayOptions: {
-					show: {
-						operation: ['fetchAtomDetails'],
-					},
-				},
-			},
-			{
-				displayName: 'Filters',
-				name: 'filters',
-				type: 'json',
-				default: '',
+                        {
+                                displayName: 'Atom ID',
+                                name: 'atomId',
+                                type: 'string',
+                                default: '',
+                                displayOptions: {
+                                        show: {
+                                                operation: ['fetchAtomDetails'],
+                                        },
+                                },
+                        },
+                        {
+                                displayName: 'Limit',
+                                name: 'limit',
+                                type: 'number',
+                                default: 10,
+                                displayOptions: {
+                                        show: {
+                                                operation: ['fetchAtoms'],
+                                        },
+                                },
+                        },
+                        {
+                                displayName: 'Offset',
+                                name: 'offset',
+                                type: 'number',
+                                default: 0,
+                                displayOptions: {
+                                        show: {
+                                                operation: ['fetchAtoms'],
+                                        },
+                                },
+                        },
+                        {
+                                displayName: 'Filters',
+                                name: 'filters',
+                                type: 'json',
+                                default: '',
 				displayOptions: {
 					show: {
 						operation: ['searchTriples'],
@@ -153,15 +176,26 @@ export class IntuitionFetch implements INodeType {
 				case 'fetchTripleById':
 					result = await module.fetchTripleById(client, this.getNodeParameter('tripleId', i) as string);
 					break;
-				case 'fetchAtoms':
-					result = await module.fetchAtoms(client);
-					break;
-				case 'fetchAtomDetails':
-					result = await module.fetchAtomDetails(client, this.getNodeParameter('atomId', i) as string);
-					break;
-				default:
-					throw new Error(`Unsupported operation: ${operation}`);
-			}
+                                case 'fetchAtoms':
+                                        result = await module.fetchAtoms(
+                                                client,
+                                                this.getNodeParameter('limit', i) as number,
+                                                this.getNodeParameter('offset', i) as number,
+                                        );
+                                        break;
+                                case 'fetchAtomDetails':
+                                        result = await module.fetchAtomDetails(client, this.getNodeParameter('atomId', i) as string);
+                                        break;
+                                case 'searchTriples':
+                                        {
+                                                const rawFilters = this.getNodeParameter('filters', i) as string | IDataObject;
+                                                const filters = typeof rawFilters === 'string' && rawFilters !== '' ? JSON.parse(rawFilters) : rawFilters;
+                                                result = await module.searchTriples(client, filters);
+                                        }
+                                        break;
+                                default:
+                                        throw new Error(`Unsupported operation: ${operation}`);
+                        }
 
 			returnData.push({ json: result as IDataObject });
 		}

--- a/nodes/IntuitionFetch/modules/Triples.ts
+++ b/nodes/IntuitionFetch/modules/Triples.ts
@@ -126,3 +126,27 @@ export async function fetchTripleById(client: GraphQLClient, tripleId: string) {
     triples: allTriples.triples.filter((t: any) => t.id === tripleId),
   };
 }
+
+export async function searchTriples(client: GraphQLClient, filters: unknown) {
+  const query = `
+    query SearchTriples($where: triples_bool_exp) {
+      triples(where: $where) {
+        id
+        subject {
+          id
+          label
+        }
+        predicate {
+          id
+          label
+        }
+        object {
+          id
+          label
+        }
+      }
+    }
+  `;
+  const variables = { where: filters ?? {} };
+  return client.request(query, variables);
+}


### PR DESCRIPTION
## Summary
- support Base testnet improvements
- add `searchTriples` query
- allow pagination for `fetchAtoms`
- document new operations

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.1.4.tgz)*
- `pnpm build` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.1.4.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_6882eb57f8048323af6863e631dba56d